### PR TITLE
chore: update documentation (improvements for Bioc)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: gDR
 Title: Umbrella package for R packages in the gDR suite
-Version: 0.99.2
-Date: 2023-04-07
+Version: 0.99.3
+Date: 2023-04-13
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),
     person("Bartosz", "Czech", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# gDR 0.99.3
+* update documentation (Bioc-compatibility)
+
 # gDR 0.99.2
 * update maintainer
 

--- a/R/data.R
+++ b/R/data.R
@@ -18,6 +18,7 @@
 #'   \item{BackgroundValue}{backgroud value}
 #'   \item{Duration}{duration}
 #' }
+#' @return data.frame
 "small_data"
 
 #' Small data.frame with raw combo data used for processing via gDR
@@ -44,4 +45,5 @@
 #'   \item{BackgroundValue}{backgroud value}
 #'   \item{Duration}{duration}
 #' }
+#' @return data.frame
 "small_combo_data"

--- a/R/package.R
+++ b/R/package.R
@@ -5,5 +5,6 @@
 #' @importFrom gDRutils fit_curves
 
 #' @keywords internal
+#' @return package help page
 "_PACKAGE"
 NULL

--- a/man/gDR-package.Rd
+++ b/man/gDR-package.Rd
@@ -5,17 +5,19 @@
 \alias{gDR}
 \alias{gDR-package}
 \title{gDR: Umbrella package for R packages in the gDR suite}
+\value{
+package help page
+}
 \description{
 Package is a part of the gDR suite. It provides info about processing functions and utilities from individual gDR packages. The vignette walks through the full processing pipeline for drug response analyses that the gDR suite offers.
 }
 \author{
-\strong{Maintainer}: Support gDR \email{gdr-support-d@gene.com} (\href{https://orcid.org/0009-0006-9310-1135}{ORCID})
+\strong{Maintainer}: Arkadiusz Gladki \email{gladki.arkadiusz@gmail.com}
 
 Authors:
 \itemize{
   \item Allison Vuong \email{vuong.allison@gene.com}
   \item Bartosz Czech
-  \item Arkadiusz Gladki
   \item Marc Hafner
   \item Dariusz Scigocki
   \item Sergiu Mocanu

--- a/man/import_data.Rd
+++ b/man/import_data.Rd
@@ -20,7 +20,9 @@ or character with file path of templates file(s)}
 \item{results_file}{data.frame, with datapaths and names of results file(s)
 or character with file path of results file(s)}
 
-\item{instrument}{character with type of instrument used}
+\item{instrument}{character with type of instrument used
+
+# fix for the NOTE in R CMD CHECK}
 }
 \value{
 a \code{data.frame}

--- a/man/small_combo_data.Rd
+++ b/man/small_combo_data.Rd
@@ -28,6 +28,9 @@ A data frame with 3600 rows and 16 variables:
 \usage{
 small_combo_data
 }
+\value{
+data.frame
+}
 \description{
 A dataset containing the ReadoutValues for combo experiments made-up of 
 3 drugs, 2 co-drugs, and 2 cell lines

--- a/man/small_data.Rd
+++ b/man/small_data.Rd
@@ -24,6 +24,9 @@ A data frame with 3300 rows and 12 variables:
 \usage{
 small_data
 }
+\value{
+data.frame
+}
 \description{
 A dataset containing the ReadoutValues for single-agent experiments 
 made-up of 10 drugs and 10 cell lines


### PR DESCRIPTION
Fix for the following WARNING in BiocCheck:
```
* WARNING: Empty or missing \value sections found in man pages.
Found in files:
man/gDR-package.Rd, man/small_combo_data.Rd, man/small_data.Rd
```