### PR TITLE
Improve logic for get_test_data()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ License: file LICENSE
 Depends:
     R (>= 4.2),
     gDRcore (>= 0.99.3),
-    gDRimport (>= 0.99.3),
+    gDRimport (>= 0.99.5),
     gDRutils (>= 0.99.4)
 Suggests:
     BumpyMatrix,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,14 +17,14 @@ Description: Package is a part of the gDR suite. It provides info about processi
 License: file LICENSE
 Depends:
     R (>= 4.2),
-    gDRcore (>= 0.99.3),
-    gDRimport (>= 0.99.5),
+    gDRcore (>= 0.99.7),
+    gDRimport (>= 0.99.6),
     gDRutils (>= 0.99.4)
 Suggests:
     BumpyMatrix,
     futile.logger,
-    gDRstyle (>= 0.99.8),
-    gDRtestData (>= 0.99.3),
+    gDRstyle (>= 0.99.11),
+    gDRtestData (>= 0.99.7),
     kableExtra,
     knitr,
     markdown,

--- a/R/data.R
+++ b/R/data.R
@@ -18,6 +18,9 @@
 #'   \item{BackgroundValue}{backgroud value}
 #'   \item{Duration}{duration}
 #' }
+#' 
+#' @usage data(small_data)
+#' 
 #' @return data.frame
 "small_data"
 
@@ -45,5 +48,8 @@
 #'   \item{BackgroundValue}{backgroud value}
 #'   \item{Duration}{duration}
 #' }
+#' 
+#' @usage data(small_combo_data)
+#' 
 #' @return data.frame
 "small_combo_data"

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -9,7 +9,7 @@
 #' 
 #' @examples
 #' td <- get_test_data()
-#' i_df <- import_data(td$m_file, td$t_files, td$r_files)
+#' i_df <- import_data(manifest_path(td), template_path(td), result_path(td))
 #' 
 #' @return a \code{data.frame}
 #'

--- a/man/gDR-package.Rd
+++ b/man/gDR-package.Rd
@@ -7,6 +7,8 @@
 \title{gDR: Umbrella package for R packages in the gDR suite}
 \value{
 package help page
+
+package help page
 }
 \description{
 Package is a part of the gDR suite. It provides info about processing functions and utilities from individual gDR packages. The vignette walks through the full processing pipeline for drug response analyses that the gDR suite offers.

--- a/man/import_data.Rd
+++ b/man/import_data.Rd
@@ -20,9 +20,7 @@ or character with file path of templates file(s)}
 \item{results_file}{data.frame, with datapaths and names of results file(s)
 or character with file path of results file(s)}
 
-\item{instrument}{character with type of instrument used
-
-# fix for the NOTE in R CMD CHECK}
+\item{instrument}{character with type of instrument used}
 }
 \value{
 a \code{data.frame}
@@ -32,6 +30,6 @@ Import raw data
 }
 \examples{
 td <- get_test_data()
-i_df <- import_data(td$m_file, td$t_files, td$r_files)
+i_df <- import_data(manifest_path(td), template_path(td), result_path(td))
 
 }

--- a/man/small_combo_data.Rd
+++ b/man/small_combo_data.Rd
@@ -26,7 +26,7 @@ A data frame with 3600 rows and 16 variables:
 }
 }
 \usage{
-small_combo_data
+data(small_combo_data)
 }
 \value{
 data.frame

--- a/man/small_data.Rd
+++ b/man/small_data.Rd
@@ -22,7 +22,7 @@ A data frame with 3300 rows and 12 variables:
 }
 }
 \usage{
-small_data
+data(small_data)
 }
 \value{
 data.frame

--- a/rplatform/dependencies.yaml
+++ b/rplatform/dependencies.yaml
@@ -6,25 +6,25 @@ pkgs:
     subdir: gDRutils
     source: GITHUB
   gDRstyle:
-    ver: '>=0.99.8'
+    ver: '>=0.99.11'
     url: gdrplatform/gDRstyle
     ref: main
     subdir: ~
     source: GITHUB
   gDRtestData:
-    ver: '>=0.99.3'
+    ver: '>=0.99.7'
     url: gdrplatform/gDRtestData
     ref: master
     subdir: ~
     source: GITHUB
   gDRcore:
-    ver: '>=0.99.3'
+    ver: '>=0.99.7'
     url: gdrplatform/gDRcore
     ref: master
     subdir: gDRcore
     source: GITHUB
   gDRimport:
-    ver: '>=0.99.3'
+    ver: '>=0.99.6'
     url: gdrplatform/gDRimport
     ref: main
     subdir: ~

--- a/vignettes/gDR.Rmd
+++ b/vignettes/gDR.Rmd
@@ -84,16 +84,16 @@ library(gDR)
 # get test data from gDRimport package
 # i.e. paths to manifest, templates and results files
 td <- get_test_data()
-td$m_file
-td$t_files
-td$r_files
+manifest_path(td)
+template_path(td)
+result_path(td)
 ```
 
 Using the convenience function `import_data`, the long table is easily created: 
 
 ```{r, echo=TRUE, results='asis', warning=FALSE, results='hide', message=FALSE} 
 # Import data
-imported_data <- import_data(td$m_file, td$t_files, td$r_files)
+imported_data <- import_data(manifest_path(td), template_path(td), result_path(td))
 head(imported_data)
 ```
 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-1924

## Why was it changed?
Refactor the code in gDRimport to meet reviewer's criteria - function `get_test_data()` returns object class S4 `gdr_test_data`. Description and calling function `get_test_data()` had to be updaeted.

(because this change is only for documentation - version of the package has not been bumped and no tests are required)

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated

# Screenshots (optional)
