### PR TITLE
build: remove obsolete reference to 'dependencies.yaml'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ FROM ${BASE_IMAGE}
 
 #================= Install gdrplatform packages
 RUN mkdir -p /mnt/vol
-COPY rplatform/dependencies.yaml rplatform/.github_access_token.txt* /mnt/vol
+COPY rplatform/.github_access_token.txt* /mnt/vol
 RUN Rscript -e 'BiocManager::install(c("gDRstyle", "gDRtestData", "gDRutils", "gDRimport", "gDRcore", "gDR"))'
 RUN sudo rm -rf /mnt/vol/*


### PR DESCRIPTION
# Summary
remove obsolete reference to 'dependencies.yaml'

# Details
Fix for the https://github.com/gdrplatform/gDR/issues/38