### PR TITLE
[GDR-2235] Adjust NEWS to Bioc format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,15 @@
 Type: Package
 Package: gDR
 Title: Umbrella package for R packages in the gDR suite
-Version: 0.99.8
-Date: 2023-08-17
+Version: 0.99.9
+Date: 2023-10-18
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),
     person("Bartosz", "Czech", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
     person("Marc", "Hafner", role = "aut"),
     person("Dariusz", "Scigocki", role = "aut"),
+    person("Janina", "Smola", role = "aut"),
     person("Sergiu", "Mocanu", role = "aut")
   )
 Description: Package is a part of the gDR suite. It reexports functions from other packages

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,55 +1,88 @@
-# gDR 0.99.8
+## 0.99.9 (2023-10-18)
+- adjust NEWS to Bioc format
+
+## 0.99.8 (2023-08-17)
 - update README 
 
-# gDR 0.99.7
+## 0.99.7 (2023-08-17)
 - clean-up
 - update documentation
 - simplify Docker-based installation
 
-# gDR 0.99.6
+## 0.99.6 (2023-05-22)
 - format the vignette with BiocStyle
 
-# gDR 0.99.5
-* fix related with data.table
+## 0.99.5 (2023-05-11)
+- fix related with data.table
 
-# gDR 0.99.4
-* switch to OSI license
+## 0.99.4 (2023-04-20)
+- switch to OSI license
 
-# gDR 0.99.3
-* update documentation (Bioc-compatibility)
+## 0.99.3 (2023-04-13)
+- update documentation (Bioc-compatibility)
 
-# gDR 0.99.2
-* update maintainer
+## 0.99.2 (2023-04-07)
+- update maintainer
 
-# gDR 0.99.1
-* update requirements (gDRcore)
+## 0.99.1 (2023-04-04)
+- update requirements (gDRcore)
 
-# gDR 0.99.0
-* switch to Bioc compatible versioning
+## 0.99.0 (2023-03-23)
+- switch to Bioc compatible versioning
 
-# gDR 1.3.7
-* drop gDRcomponents dependency
+## 0.1.3.7 (2023-03-23)
+- drop gDRcomponents dependency
 
-# gDR 1.3.2
-* update deps
+## 0.1.3.6 (2023-03-13)
+- bugfix - assure proper path to shared_dir in the vignette
 
-# gDR 1.3.0
-* release
+## 0.1.3.5 (2023-03-08)
+- add functions from gDRcomponents
 
-# gDR 0.0.7
-* remove unnecessary exports
+## 0.1.3.4 (2023-02-28)
+- update vignette
 
-# gDR 0.0.6
-* update version and package dependencies
+## 0.1.3.3 (2023-01-18)
+- fixed NOTES
 
-# gDR 0.0.5
-* update vignette
+## 0.1.3.2 (2022-12-15)
+- update deps
 
-# gDR 0.0.3
-* update roxygen documentation
+## 0.1.3.1 (2022-10-05)
+- add BioCparallel and kableExtra as dep
 
-# gDR 0.0.2
-* add exemple data
+## 0.1.3.0 (2022-06-02)
+- release 1.3.0
 
-# gDR 0.0.1
-* initial version
+## 0.0.0.12 (2022-04-21)
+- update unit tests
+
+## 0.0.0.11 (2022-04-21)
+- remove redundant function argument
+
+## 0.0.0.10 (2022-04-20)
+- adjust for removal of large RDS files from gDRtestData
+
+## 0.0.0.9 (2021-09-13)
+- update CODEOWNERS to use teams
+
+## 0.0.0.7 (2021-09-13)
+- remove unnecessary exports
+
+## 0.0.0.6 (2021-09-13)
+- update version and package dependencies
+
+## 0.0.0.5 (2021-09-13)
+- update vignette
+
+## 0.0.0.4 (2021-06-25)
+- update version and package dependencies
+
+## 0.0.0.3 (2021-06-25)
+- update roxygen documentation
+
+## 0.0.0.2 (2021-06-24)
+- add example data
+
+## 0.0.0.1 (2021-02-03)
+- initial version


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2235](https://jira.gene.com/jira/browse/GDR-2235)

To test: install package and run `utils::news(package = "gDR")` (check if all data item are present)
You should see in help window
![gDR](https://github.com/gdrplatform/gDR/assets/31825957/de8b983b-856d-4da6-ad5e-6c098746b0d4)

NULL in console means error!

## Why was it changed?
To adjust to Bioc rules.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
