### PR TITLE
[GDR-2258] Update package vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: gDR
 Title: Umbrella package for R packages in the gDR suite
-Version: 1.1.1
-Date: 2023-11-22
+Version: 1.1.2
+Date: 2024-01-19
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),
     person("Bartosz", "Czech", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.1.2 (2024-01-19)
+- update package vignette
+
 ## 1.1.1 (2023-11-22)
 - sync main with devel branch
 

--- a/vignettes/gDR.Rmd
+++ b/vignettes/gDR.Rmd
@@ -42,28 +42,33 @@ This data structure is the core data structure that all downstream processing fu
 ## Overview
 The gDR suite was designed in a modular manner, such that a user can jump into the "standard" end-to-end gDR processing pipeline at several entry points as is suitable for his or her needs. The full pipeline involves:
 
+```              
+      manifest, template(s), raw data
+                        |
+                        |  1. Aggregating all raw data and metadata
+                        |  into a single long table. 
+                        |
+                        V
+              single, long table
+                        |
+                        |  2. Transforming the long table into 
+                        |  a SummarizedExperiment object with BumpyMatrix assays 
+                        |  by specifying what columns belong on rows, 
+                        |  columns, and nested.
+                        |
+                        V
+          SummarizedExperiment object
+          with raw and treated assays
+                        |
+                        |  3. Normalizing, averaging, and fitting data.
+                        |
+                        V
+          SummarizedExperiment object
+          with raw, treated, normalized,
+           averaged, and metric assays, 
+   ready for use by downstream visualization
               
-                           manifest, template(s), raw data
-                                             |
-                                             |  1. Aggregating all raw data and metadata into a single long table.
-                                             V
-                                   single, long table
-                                             |
-                                             |  2. Transforming the long table into a SummarizedExperiment object 
-                                             |  with BumpyMatrix assays by specifying what columns belong on rows, 
-                                             |  columns, and nested.
-                                             |
-                                             V
-                               SummarizedExperiment object
-                               with raw and treated assays
-                                             |
-                                             |  3. Normalizing, averaging, and fitting data.
-                                             |
-                                             V
-                               SummarizedExperiment object
-                               with raw, treated, normalized,
-                                averaged, and metric assays, 
-                        ready for use by downstream visualization
+ ```
  
 A user should be able to enter any part of this pipeline as long as they are able to create the intermediate object
 (i.e., the individual manifest, template, and raw data files, or a single, long table, or a SummarizedExperiment object with Bumpy assays).
@@ -92,7 +97,8 @@ Using the convenience function `import_data`, the long table is easily created:
 
 ```{r, echo=TRUE, results='asis', warning=FALSE, results='hide', message=FALSE} 
 # Import data
-imported_data <- import_data(manifest_path(td), template_path(td), result_path(td))
+imported_data <- 
+  import_data(manifest_path(td), template_path(td), result_path(td))
 head(imported_data)
 ```
 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2358](https://jira.gene.com/jira/browse/GDR-2358) [doc](https://docs.google.com/document/d/1tljj5R4S1jt8L7zkQBOWaHJaT1gicaV6ZmIIoRTUw0E/edit)

## Why was it changed?
To make all code visible (compare [bioc](https://bioconductor.org/packages/3.18/bioc/vignettes/gDR/inst/doc/gDR.html) )

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
old
![bioc_gDr](https://github.com/gdrplatform/gDR/assets/31825957/cd0b0972-a0b1-472c-acb0-6fa133c775a7)
new
![new_gDR](https://github.com/gdrplatform/gDR/assets/31825957/11c8c47f-6640-4b64-bea8-804b9cbdac44)
