### PR TITLE
Gdr 2419

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: gDR
 Title: Umbrella package for R packages in the gDR suite
-Version: 1.1.4
-Date: 2024-02-14
+Version: 1.1.5
+Date: 2024-02-26
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),
     person("Bartosz", "Czech", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,9 +5,12 @@ Version: 1.1.5
 Date: 2024-02-26
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),
-    person("Bartosz", "Czech", role = "aut"),
-    person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
-    person("Marc", "Hafner", role = "aut"),
+    person("Bartosz", "Czech", role = "aut",
+           comment = c(ORCID = "0000-0002-9908-3007")),
+    person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com",
+           comment = c(ORCID = "0000-0002-7059-6378")),
+    person("Marc", "Hafner", role = "aut",
+           comment = c(ORCID = "0000-0003-1337-7598")),
     person("Dariusz", "Scigocki", role = "aut"),
     person("Janina", "Smola", role = "aut"),
     person("Sergiu", "Mocanu", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,106 +1,111 @@
-## 1.1.4 (2024-02-12)
-- make documentation compatible with pkdgdown
+## gDR 1.1.5 - 2024-02-26
+* improve pkgdown site
+  * improved references
+  * valid NEWS.md
 
-## 1.1.3 (2024-01-22)
-- add new description fields
+## gDR 1.1.4 - 2024-02-12
+* make documentation compatible with pkdgdown
 
-## 1.1.2 (2024-01-19)
-- update package vignette
+## gDR 1.1.3 - 2024-01-22
+* add new description fields
 
-## 1.1.1 (2023-11-22)
-- sync main with devel branch
+## gDR 1.1.2 - 2024-01-19
+* update package vignette
 
-## 1.1.0 (2023-10-24)
-- release Bioc 3.18
+## gDR 1.1.1 - 2023-11-22
+* sync main with devel branch
 
-## 1.0.0 (2023-10-24)
-- prerelease Bioc 3.18
+## gDR 1.1.0 - 2023-10-24
+* release Bioc 3.18
 
-## 0.99.9 (2023-10-18)
-- adjust NEWS to Bioc format
+## gDR 1.0.0 - 2023-10-24
+* prerelease Bioc 3.18
 
-## 0.99.8 (2023-08-17)
-- update README 
+## gDR 0.99.9 - 2023-10-18
+* adjust NEWS to Bioc format
 
-## 0.99.7 (2023-08-17)
-- clean-up
-- update documentation
-- simplify Docker-based installation
+## gDR 0.99.8 - 2023-08-17
+* update README 
 
-## 0.99.6 (2023-05-22)
-- format the vignette with BiocStyle
+## gDR 0.99.7 - 2023-08-17
+* clean-up
+* update documentation
+* simplify Docker-based installation
 
-## 0.99.5 (2023-05-11)
-- fix related with data.table
+## gDR 0.99.6 - 2023-05-22
+* format the vignette with BiocStyle
 
-## 0.99.4 (2023-04-20)
-- switch to OSI license
+## gDR 0.99.5 - 2023-05-11
+* fix related with data.table
 
-## 0.99.3 (2023-04-13)
-- update documentation (Bioc-compatibility)
+## gDR 0.99.4 - 2023-04-20
+* switch to OSI license
 
-## 0.99.2 (2023-04-07)
-- update maintainer
+## gDR 0.99.3 - 2023-04-13
+* update documentation - Bioc-compatibility
 
-## 0.99.1 (2023-04-04)
-- update requirements (gDRcore)
+## gDR 0.99.2 - 2023-04-07
+* update maintainer
 
-## 0.99.0 (2023-03-23)
-- switch to Bioc compatible versioning
+## gDR 0.99.1 - 2023-04-04
+* update requirements - gDRcore
 
-## 0.1.3.7 (2023-03-23)
-- drop gDRcomponents dependency
+## gDR 0.99.0 - 2023-03-23
+* switch to Bioc compatible versioning
 
-## 0.1.3.6 (2023-03-13)
-- bugfix - assure proper path to shared_dir in the vignette
+## gDR 0.1.3.7 - 2023-03-23
+* drop gDRcomponents dependency
 
-## 0.1.3.5 (2023-03-08)
-- add functions from gDRcomponents
+## gDR 0.1.3.6 - 2023-03-13
+* bugfix - assure proper path to shared_dir in the vignette
 
-## 0.1.3.4 (2023-02-28)
-- update vignette
+## gDR 0.1.3.5 - 2023-03-08
+* add functions from gDRcomponents
 
-## 0.1.3.3 (2023-01-18)
-- fixed NOTES
+## gDR 0.1.3.4 - 2023-02-28
+* update vignette
 
-## 0.1.3.2 (2022-12-15)
-- update deps
+## gDR 0.1.3.3 - 2023-01-18
+* fixed NOTES
 
-## 0.1.3.1 (2022-10-05)
-- add BioCparallel and kableExtra as dep
+## gDR 0.1.3.2 - 2022-12-15
+* update deps
 
-## 0.1.3.0 (2022-06-02)
-- release 1.3.0
+## gDR 0.1.3.1 - 2022-10-05
+* add BioCparallel and kableExtra as dep
 
-## 0.0.0.12 (2022-04-21)
-- update unit tests
+## gDR 0.1.3.0 - 2022-06-02
+* release 1.3.0
 
-## 0.0.0.11 (2022-04-21)
-- remove redundant function argument
+## gDR 0.0.0.12 - 2022-04-21
+* update unit tests
 
-## 0.0.0.10 (2022-04-20)
-- adjust for removal of large RDS files from gDRtestData
+## gDR 0.0.0.11 - 2022-04-21
+* remove redundant function argument
 
-## 0.0.0.9 (2021-09-13)
-- update CODEOWNERS to use teams
+## gDR 0.0.0.10 - 2022-04-20
+* adjust for removal of large RDS files from gDRtestData
 
-## 0.0.0.7 (2021-09-13)
-- remove unnecessary exports
+## gDR 0.0.0.9 - 2021-09-13
+* update CODEOWNERS to use teams
 
-## 0.0.0.6 (2021-09-13)
-- update version and package dependencies
+## gDR 0.0.0.7 - 2021-09-13
+* remove unnecessary exports
 
-## 0.0.0.5 (2021-09-13)
-- update vignette
+## gDR 0.0.0.6 - 2021-09-13
+* update version and package dependencies
 
-## 0.0.0.4 (2021-06-25)
-- update version and package dependencies
+## gDR 0.0.0.5 - 2021-09-13
+* update vignette
 
-## 0.0.0.3 (2021-06-25)
-- update roxygen documentation
+## gDR 0.0.0.4 - 2021-06-25
+* update version and package dependencies
 
-## 0.0.0.2 (2021-06-24)
-- add example data
+## gDR 0.0.0.3 - 2021-06-25
+* update roxygen documentation
 
-## 0.0.0.1 (2021-02-03)
-- initial version
+## gDR 0.0.0.2 - 2021-06-24
+* add example data
+
+## gDR 0.0.0.1 - 2021-02-03
+* initial version

--- a/R/data.R
+++ b/R/data.R
@@ -21,6 +21,7 @@
 #' 
 #' @usage data(small_data)
 #' 
+#' @keywords data
 #' @return data.table
 "small_data"
 
@@ -51,5 +52,6 @@
 #' 
 #' @usage data(small_combo_data)
 #' 
+#' @keywords data
 #' @return data.table
 "small_combo_data"

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -13,6 +13,7 @@
 #' 
 #' @return a \code{data.table}
 #'
+#' @keywords import
 #' @export
 #'
 import_data <- function(manifest_file,

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ gDR is an umbrella package for the gDR programmatic R interface.
 
 The gDR suite offers a full stack solution for processing drug response data. This enables a range of users across computational savvy, (i.e. lab scientists and computational scientists alike) to access the same, standardized data. The suite is made up of several core R packages.
 
-![Figure 1. The overview of R packages that are available via gDR umbrella package.  ](https://raw.githubusercontent.com/gdrplatform/gDR/test_ci_pkgdown/inst/images/overview.png)  
+![Figure 1. The overview of R packages that are available via gDR umbrella package.  ](https://raw.githubusercontent.com/gdrplatform/gDR/main/inst/images/overview.png)  
 
+# Website
+A package website is available under [this link](https://gdrplatform.github.io/gDR/).
 
 # Installation
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,10 @@ url: https://gdrplatform.github.io/gDR/
 template:
   bootstrap: 5
 
+reference:
+- title: Import
+- contents:
+  - has_keyword("import")
+- title: Data
+- contents:
+  - has_keyword("data")

--- a/man/import_data.Rd
+++ b/man/import_data.Rd
@@ -33,3 +33,4 @@ td <- get_test_data()
 i_df <- import_data(manifest_path(td), template_path(td), result_path(td))
 
 }
+\keyword{import}

--- a/man/small_combo_data.Rd
+++ b/man/small_combo_data.Rd
@@ -35,4 +35,4 @@ data.table
 A dataset containing the ReadoutValues for combo experiments made-up of
 3 drugs, 2 co-drugs, and 2 cell lines
 }
-\keyword{datasets}
+\keyword{data}

--- a/man/small_data.Rd
+++ b/man/small_data.Rd
@@ -31,4 +31,4 @@ data.table
 A dataset containing the ReadoutValues for single-agent experiments
 made-up of 10 drugs and 10 cell lines
 }
-\keyword{datasets}
+\keyword{data}


### PR DESCRIPTION
# Description
Improve pkgdown site
## What changed?
- updated news and added reference sections
- Related JIRA issue:  GDR-2419
- pkgdown site link: https://gdrplatform.github.io/gDR/

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
