### PR TITLE
fix: resolve gDRstyle linting violations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ VignetteBuilder: knitr
 ByteCompile: TRUE
 LazyLoad: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3
 SwitchrLibrary: gDR
 DeploySubPath: gDR
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: gDR
 Title: Umbrella package for R packages in the gDR suite
-Version: 1.11.1
-Date: 2026-04-29
+Version: 1.11.2
+Date: 2026-05-26
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),
     person("Bartosz", "Czech", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -77,7 +77,7 @@
 ## gDR 0.99.0 - 2023-03-23
 * switch to Bioc compatible versioning
 
-## gDR 0.1.3.7 - 2023-03-23
+## gDR 0.1.37 - 2023-03-23
 * drop gDRcomponents dependency
 
 ## gDR 0.1.3.6 - 2023-03-13

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## gDR 1.11.2 - 2026-05-26
-* fix linting violations from updated gDRstyle rules
+* apply updated gDRstyle rules
 
 ## gDR 1.11.1 - 2026-04-29
 * synchronize Bioconductor and GitHub versioning

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDR 1.11.2 - 2026-05-26
+* fix linting violations from updated gDRstyle rules
+
 ## gDR 1.11.1 - 2026-04-29
 * synchronize Bioconductor and GitHub versioning
 

--- a/R/data.R
+++ b/R/data.R
@@ -1,6 +1,6 @@
 #' Small data.table with raw data used for processing via gDR
 #'
-#' A dataset containing the ReadoutValues for single-agent experiments 
+#' A dataset containing the ReadoutValues for single-agent experiments
 #' made-up of 10 drugs and 10 cell lines
 #'
 #' @format A data frame with 3300 rows and 12 variables:
@@ -18,16 +18,16 @@
 #'   \item{BackgroundValue}{backgroud value}
 #'   \item{Duration}{duration}
 #' }
-#' 
+#'
 #' @usage data(small_data)
-#' 
+#'
 #' @keywords data
 #' @return data.table
 "small_data"
 
 #' Small data.table with raw combo data used for processing via gDR
 #'
-#' A dataset containing the ReadoutValues for combo experiments made-up of 
+#' A dataset containing the ReadoutValues for combo experiments made-up of
 #' 3 drugs, 2 co-drugs, and 2 cell lines
 #'
 #' @format A data frame with 3600 rows and 16 variables:
@@ -49,9 +49,9 @@
 #'   \item{BackgroundValue}{backgroud value}
 #'   \item{Duration}{duration}
 #' }
-#' 
+#'
 #' @usage data(small_combo_data)
-#' 
+#'
 #' @keywords data
 #' @return data.table
 "small_combo_data"

--- a/R/data.R
+++ b/R/data.R
@@ -1,7 +1,7 @@
 #' Small data.table with raw data used for processing via gDR
 #'
 #' A dataset containing the ReadoutValues for single-agent experiments
-#' made-up of 10 drugs and 10 cell lines
+#' made up of 10 drugs and 10 cell lines
 #'
 #' @format A data frame with 3300 rows and 12 variables:
 #' \describe{
@@ -27,7 +27,7 @@
 
 #' Small data.table with raw combo data used for processing via gDR
 #'
-#' A dataset containing the ReadoutValues for combo experiments made-up of
+#' A dataset containing the ReadoutValues for combo experiments made up of
 #' 3 drugs, 2 co-drugs, and 2 cell lines
 #'
 #' @format A data frame with 3600 rows and 16 variables:

--- a/R/gDR-package.R
+++ b/R/gDR-package.R
@@ -1,4 +1,4 @@
-#' @note To learn more about functions start with `help(package = "gDR")` 
+#' @note To learn more about functions start with `help(package = "gDR")`
 #' @keywords internal
 #' @return package help page
 "_PACKAGE"

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -6,11 +6,11 @@
 #' @param results_file character, with datapaths and names of results file(s)
 #' or character with file path of results file(s)
 #' @param instrument string with type of instrument used
-#' 
+#'
 #' @examples
 #' td <- get_test_data()
 #' i_df <- import_data(manifest_path(td), template_path(td), result_path(td))
-#' 
+#'
 #' @return a \code{data.table}
 #'
 #' @keywords import

--- a/man/small_combo_data.Rd
+++ b/man/small_combo_data.Rd
@@ -32,7 +32,7 @@ data(small_combo_data)
 data.table
 }
 \description{
-A dataset containing the ReadoutValues for combo experiments made-up of
+A dataset containing the ReadoutValues for combo experiments made up of
 3 drugs, 2 co-drugs, and 2 cell lines
 }
 \keyword{data}

--- a/man/small_data.Rd
+++ b/man/small_data.Rd
@@ -29,6 +29,6 @@ data.table
 }
 \description{
 A dataset containing the ReadoutValues for single-agent experiments
-made-up of 10 drugs and 10 cell lines
+made up of 10 drugs and 10 cell lines
 }
 \keyword{data}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,10 +1,10 @@
 context("utils")
 
 test_that("import_data", {
-  
+
   # Define path for data stored in gDR package
   dataDir <- system.file("extdata", "data1", package = "gDRimport")
-  
+
   # Extract path for example raw_data
   manifest <- list.files(dataDir, pattern = "manifest", full.names = TRUE)
   template <- list.files(dataDir, pattern = "Template", full.names = TRUE)

--- a/vignettes/gDR.Rmd
+++ b/vignettes/gDR.Rmd
@@ -138,7 +138,7 @@ se
 ```
 
 ## runDrugResponseProcessingPipeline
-Steps (2) and (3) can be combined into a single step through a convenience function: `runDrugResponseProcessingPipeline`.  Moreover, the output is `MultiAssayExperiment` object with one experiment per each detected data type. Currently four data types are supported: 'single-agent', 'cotreatment', 'codilution' and 'matrix'. The first three data types are processed via the 'single-agent' model while the 'marix' data is processed via the 'combintation' model.
+Steps (2) and (3) can be combined into a single step through a convenience function: `runDrugResponseProcessingPipeline`.  Moreover, the output is `MultiAssayExperiment` object with one experiment per each detected data type. Currently four data types are supported: 'single-agent', 'cotreatment', 'codilution' and 'matrix'. The first three data types are processed via the 'single-agent' model while the 'matrix' data is processed via the 'combination' model.
 
 ```{r, echo=TRUE, results='asis', warning=FALSE, results='hide', message=FALSE}
 # Run gDR pipeline

--- a/vignettes/gDR.Rmd
+++ b/vignettes/gDR.Rmd
@@ -34,7 +34,7 @@ We are happy to share with you our packages for importing, processing and managi
 - gDRutils
 - gDRtestData
 
-## Data structures 
+## Data structures
 The gDR data model is based on the SummarizedExperiment and BumpyMatrix. If readers are unfamiliar with these data models, we recommend first reading [SummarizedExperiment vignettes](https://bioconductor.org/packages/release/bioc/vignettes/SummarizedExperiment/inst/doc/SummarizedExperiment.html), followed by the [BumpyMatrix vignettes](https://www.bioconductor.org/packages/devel/bioc/vignettes/BumpyMatrix/inst/doc/BumpyMatrix.html). The SummarizedExperiment data structure enables ease of subsetting within the SummarizedExperiment object, but also provides ease when trying to correlate drug response data with genomic data, as these data may jointly stored in a MultiAssayExperiment. The BumpyMatrix allows for storage of multi-dimensional data while retaining a matrix abstraction.
 
 This data structure is the core data structure that all downstream processing functions as well as visualization tools operate off of.
@@ -42,18 +42,18 @@ This data structure is the core data structure that all downstream processing fu
 ## Overview
 The gDR suite was designed in a modular manner, such that a user can jump into the "standard" end-to-end gDR processing pipeline at several entry points as is suitable for his or her needs. The full pipeline involves:
 
-```              
+```
       manifest, template(s), raw data
                         |
                         |  1. Aggregating all raw data and metadata
-                        |  into a single long table. 
+                        |  into a single long table.
                         |
                         V
               single, long table
                         |
-                        |  2. Transforming the long table into 
-                        |  a SummarizedExperiment object with BumpyMatrix assays 
-                        |  by specifying what columns belong on rows, 
+                        |  2. Transforming the long table into
+                        |  a SummarizedExperiment object with BumpyMatrix assays
+                        |  by specifying what columns belong on rows,
                         |  columns, and nested.
                         |
                         V
@@ -65,11 +65,11 @@ The gDR suite was designed in a modular manner, such that a user can jump into t
                         V
           SummarizedExperiment object
           with raw, treated, normalized,
-           averaged, and metric assays, 
+           averaged, and metric assays,
    ready for use by downstream visualization
-              
+
  ```
- 
+
 A user should be able to enter any part of this pipeline as long as they are able to create the intermediate object
 (i.e., the individual manifest, template, and raw data files, or a single, long table, or a SummarizedExperiment object with Bumpy assays).
 
@@ -93,11 +93,11 @@ template_path(td)
 result_path(td)
 ```
 
-Using the convenience function `import_data`, the long table is easily created: 
+Using the convenience function `import_data`, the long table is easily created:
 
-```{r, echo=TRUE, results='asis', warning=FALSE, results='hide', message=FALSE} 
+```{r, echo=TRUE, results='asis', warning=FALSE, results='hide', message=FALSE}
 # Import data
-imported_data <- 
+imported_data <-
   import_data(manifest_path(td), template_path(td), result_path(td))
 head(imported_data)
 ```
@@ -128,7 +128,7 @@ Note that this has created a SummarizedExperiment object with `rowData`, `colDat
 
 
 ## Averaging and fitting data (3)
-Next, we can average and fit the data of interest. 
+Next, we can average and fit the data of interest.
 ```{r, echo=TRUE, results='asis', warning=FALSE, results='hide', message=FALSE}
 se <- average_SE(se, data_type = "single-agent")
 se <- fit_SE(se, data_type = "single-agent")
@@ -138,7 +138,7 @@ se
 ```
 
 ## runDrugResponseProcessingPipeline
-Steps (2) and (3) can be combined into a single step through a convenience function: `runDrugResponseProcessingPipeline`.  Moreover, the output is `MultiAssayExperiment` object with one experiment per each detected data type. Currently four data types are supported: 'single-agent', 'cotreatment', 'codilution' and 'matrix'. The first three data types are processed via the 'single-agent' model while the 'marix' data is processed via the 'combintation' model. 
+Steps (2) and (3) can be combined into a single step through a convenience function: `runDrugResponseProcessingPipeline`.  Moreover, the output is `MultiAssayExperiment` object with one experiment per each detected data type. Currently four data types are supported: 'single-agent', 'cotreatment', 'codilution' and 'matrix'. The first three data types are processed via the 'single-agent' model while the 'marix' data is processed via the 'combintation' model.
 
 ```{r, echo=TRUE, results='asis', warning=FALSE, results='hide', message=FALSE}
 # Run gDR pipeline


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-1014

- Fix trailing whitespace and blank lines
- Replace nrow/ncol with NROW/NCOL (undesirable_function_linter)
- Fix paste_linter violations (paste0+collapse, toString, strrep, file.path)
- Fix seq_linter violations (seq_along, seq_len)
- Refactor functions exceeding cyclocomp limit of 25 (extract helper functions)
- Fix test linters (yoda_test, expect_true_false)
- Remove undesirable operators (|> pipes)

## Why was it changed?
Updated gDRstyle linting rules require compliance across all gDR packages.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated