### PR TITLE
GDR-3420: add custom annotation support to import_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: gDR
 Title: Umbrella package for R packages in the gDR suite
-Version: 1.11.2
+Version: 1.11.3
 Date: 2026-05-26
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDR 1.11.3 - 2026-06-08
+* add custom annotation support to `import_data`
+
 ## gDR 1.11.2 - 2026-05-26
 * apply updated gDRstyle rules
 

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -6,6 +6,10 @@
 #' @param results_file character, with datapaths and names of results file(s)
 #' or character with file path of results file(s)
 #' @param instrument string with type of instrument used
+#' @param cell_line_annotation optional data.table with cell line annotations;
+#'   if NULL (default), annotations are looked up from gDRinternal or gDRtestData
+#' @param drug_annotation optional data.table with drug annotations;
+#'   if NULL (default), annotations are looked up from gDRinternal or gDRtestData
 #'
 #' @examples
 #' td <- get_test_data()
@@ -19,12 +23,16 @@
 import_data <- function(manifest_file,
                         template_file,
                         results_file,
-                        instrument = "EnVision") {
+                        instrument = "EnVision",
+                        cell_line_annotation = NULL,
+                        drug_annotation = NULL) {
   loaded_data <- load_data(manifest_file = manifest_file,
                            df_template_files = template_file,
                            results_file = results_file,
                            instrument = instrument)
   merge_data(manifest = loaded_data$manifest,
              treatments = loaded_data$treatments,
-             data = loaded_data$data)
+             data = loaded_data$data,
+             cell_line_annotation = cell_line_annotation,
+             drug_annotation = drug_annotation)
 }

--- a/man/import_data.Rd
+++ b/man/import_data.Rd
@@ -8,7 +8,9 @@ import_data(
   manifest_file,
   template_file,
   results_file,
-  instrument = "EnVision"
+  instrument = "EnVision",
+  cell_line_annotation = NULL,
+  drug_annotation = NULL
 )
 }
 \arguments{
@@ -21,6 +23,12 @@ or character with file path of templates file(s)}
 or character with file path of results file(s)}
 
 \item{instrument}{string with type of instrument used}
+
+\item{cell_line_annotation}{optional data.table with cell line annotations;
+if NULL (default), annotations are looked up from gDRinternal or gDRtestData}
+
+\item{drug_annotation}{optional data.table with drug annotations;
+if NULL (default), annotations are looked up from gDRinternal or gDRtestData}
 }
 \value{
 a \code{data.table}


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-3420

Add optional `cell_line_annotation` and `drug_annotation` parameters to `import_data()`, passing them through to `gDRcore::merge_data()`.

## Why was it changed?
Companion to gdrplatform/gDRcore#197 — enables open-source users to supply their own annotation CSVs at the top-level entry point.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated