### PR TITLE
chore: align DESCRIPTION date with NEWS entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gDR
 Title: Umbrella package for R packages in the gDR suite
 Version: 1.11.3
-Date: 2026-05-26
+Date: 2026-06-08
 Authors@R: c(
     person("Allison", "Vuong", , "vuong.allison@gene.com", role = "aut"),
     person("Bartosz", "Czech", role = "aut",


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-3530

Set the DESCRIPTION `Date` for 1.11.3 to 2026-06-08 so it matches the NEWS.md entry `## gDR 1.11.3 - 2026-06-08`. The version bump left the date at the previous release's value (2026-05-26).

## Why was it changed?
`lintVersionConsistency()` (new in the gDRstyle contribution linters) fails when the DESCRIPTION date and the newest NEWS date disagree. Aligning them keeps `main` green once the linters gate every MR.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
